### PR TITLE
Add basic not found page

### DIFF
--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function NotFound() {
+  return (
+    <div>
+      This page doesn&apos;t exist 😢! Check your URL for typos.
+    </div>
+  );
+}
+
+export default NotFound;


### PR DESCRIPTION
Created a 404 not found page if the user queries an endpoint that does not exist.
<img width="1792" alt="Screenshot 2024-01-10 at 9 14 30 PM" src="https://github.com/lablueprint/global-green/assets/54759887/d0da6824-63c5-4fc4-ac52-f94615efa325">
